### PR TITLE
Bugfix/antimeridian geoid

### DIFF
--- a/dem_handler/dem/cop_glo30.py
+++ b/dem_handler/dem/cop_glo30.py
@@ -82,7 +82,7 @@ def get_cop30_dem_for_bounds(
         # independently processed
         logger.info("Producing raster for Eastern Hemisphere bounds")
         save_path = Path(save_path)
-        geoid_tif_path = Path(geoid_tif_path) 
+        geoid_tif_path = Path(geoid_tif_path)
         eastern_dem_save_path = save_path.parent.joinpath(
             save_path.stem + "_eastern" + save_path.suffix
         )
@@ -137,8 +137,12 @@ def get_cop30_dem_for_bounds(
         logging.info(
             f"Reprojecting Eastern and Western hemisphere rasters to EPSG:{target_crs}"
         )
-        eastern_dem, eastern_profile = reproject_raster(eastern_dem_save_path, target_crs)
-        western_dem, western_profile = reproject_raster(western_dem_save_path, target_crs)
+        eastern_dem, eastern_profile = reproject_raster(
+            eastern_dem_save_path, target_crs
+        )
+        western_dem, western_profile = reproject_raster(
+            western_dem_save_path, target_crs
+        )
 
         logging.info(f"Merging across antimeridian")
         dem_array, dem_profile = merge_arrays_with_geometadata(
@@ -243,6 +247,10 @@ def get_cop30_dem_for_bounds(
             elif download_geoid and not Path(geoid_tif_path).exists():
                 logging.info(f"Downloading the egm_08 geoid")
                 download_egm_08_geoid(geoid_tif_path, bounds=adjusted_bounds.bounds)
+            elif download_geoid and Path(geoid_tif_path).exists():
+                logging.info(
+                    f"Skipping download. Geoid file already exists at provided path : {geoid_tif_path}. Remove file or change `geoid_tif_path` to use different file."
+                )
 
             logging.info(f"Using geoid file: {geoid_tif_path}")
             dem_array = remove_geoid(

--- a/dem_handler/dem/cop_glo30.py
+++ b/dem_handler/dem/cop_glo30.py
@@ -82,18 +82,22 @@ def get_cop30_dem_for_bounds(
         # independently processed
         logger.info("Producing raster for Eastern Hemisphere bounds")
         save_path = Path(save_path)
-        eastern_save_path = save_path.parent.joinpath(
+        geoid_tif_path = Path(geoid_tif_path) 
+        eastern_dem_save_path = save_path.parent.joinpath(
             save_path.stem + "_eastern" + save_path.suffix
+        )
+        eastern_geoid_tif_path = geoid_tif_path.parent.joinpath(
+            geoid_tif_path.stem + "_eastern" + geoid_tif_path.suffix
         )
         eastern_output = get_cop30_dem_for_bounds(
             bounds_eastern,
-            eastern_save_path,
+            eastern_dem_save_path,
             ellipsoid_heights,
             adjust_at_high_lat=adjust_at_high_lat,
             buffer_pixels=buffer_pixels,
             cop30_index_path=cop30_index_path,
             cop30_folder_path=cop30_folder_path,
-            geoid_tif_path=geoid_tif_path,
+            geoid_tif_path=eastern_geoid_tif_path,
             download_dem_tiles=download_dem_tiles,
             download_geoid=download_geoid,
             num_cpus=num_cpus,
@@ -103,18 +107,21 @@ def get_cop30_dem_for_bounds(
         )
 
         logger.info("Producing raster for Western Hemisphere bounds")
-        western_save_path = save_path.parent.joinpath(
+        western_dem_save_path = save_path.parent.joinpath(
             save_path.stem + "_western" + save_path.suffix
+        )
+        western_geoid_tif_path = geoid_tif_path.parent.joinpath(
+            geoid_tif_path.stem + "_western" + geoid_tif_path.suffix
         )
         western_output = get_cop30_dem_for_bounds(
             bounds_western,
-            western_save_path,
+            western_dem_save_path,
             ellipsoid_heights,
             adjust_at_high_lat=adjust_at_high_lat,
             buffer_pixels=buffer_pixels,
             cop30_index_path=cop30_index_path,
             cop30_folder_path=cop30_folder_path,
-            geoid_tif_path=geoid_tif_path,
+            geoid_tif_path=western_geoid_tif_path,
             download_dem_tiles=download_dem_tiles,
             download_geoid=download_geoid,
             num_cpus=num_cpus,
@@ -130,8 +137,8 @@ def get_cop30_dem_for_bounds(
         logging.info(
             f"Reprojecting Eastern and Western hemisphere rasters to EPSG:{target_crs}"
         )
-        eastern_dem, eastern_profile = reproject_raster(eastern_save_path, target_crs)
-        western_dem, western_profile = reproject_raster(western_save_path, target_crs)
+        eastern_dem, eastern_profile = reproject_raster(eastern_dem_save_path, target_crs)
+        western_dem, western_profile = reproject_raster(western_dem_save_path, target_crs)
 
         logging.info(f"Merging across antimeridian")
         dem_array, dem_profile = merge_arrays_with_geometadata(


### PR DESCRIPTION
- Bugfix for the geoid handling over the antimeridian. The geoid file is not replaced if `download_geoid = True` and the file already exists. The same geoid filename was being used for both the east and west sides of the AM. This means when the file is used for the second time, it does not intersect with the dem. A fix has been added to create separate files for either side of the AM. A warning has also been added to let the user know that an existing geoid file is being used. 

- Perhaps the default behaviour should always be to replace the existing geoid if `download_geoid = True`? Otherwise, given the file is not deleted it could accidentally be used across multiple areas if the filename is not changed. 


Error

```bash
INFO:dem_handler.dem.cop_glo30:Getting cop30m dem for bounds: (-177.884048, -78.176201, 178.838364, -75.697151)
WARNING:dem_handler.dem.cop_glo30:DEM crosses the dateline/antimeridian. Bounds will be split and processed.
WARNING:dem_handler.utils.spatial:Data will be returned in EPSG:3031 projection
INFO:dem_handler.dem.cop_glo30:Splitting bounds into left and right side of antimeridian
INFO:dem_handler.utils.spatial:Eastern Hemisphere bounds: (178.838364, -78.176201, 180, -75.697151)
INFO:dem_handler.utils.spatial:Western Hemisphere bounds: (-180, -78.176201, -177.884048, -75.697151)
INFO:dem_handler.dem.cop_glo30:Producing raster for Eastern Hemisphere bounds
INFO:dem_handler.dem.cop_glo30:Getting cop30m dem for bounds: (178.838364, -78.176201, 180, -75.697151)
INFO:root:Adjusting bounds at high southern latitudes
INFO:dem_handler.dem.cop_glo30:Getting cop30m dem for adjusted bounds: (178.59266474925684, -78.17861448123979, 180.0, -75.69424135118291)
(178.838364, -78.176201, 180.0, -75.697151)
(178.59208333333333, -78.17875000000001, 180.00041666666667, -75.69402777777778)
INFO:dem_handler.dem.cop_glo30:Finding intersecting DEM files from: /home/rtc_user/miniconda3/envs/sar-pipeline/lib/python3.12/site-packages/dem_handler/data/copdem_tindex_filename.gpkg
POLYGON ((180.00041666666667 -78.17875000000001, 178.59208333333333 -78.17875000000001, 178.59208333333333 -75.69402777777778, 180.00041666666667 -75.69402777777778, 180.00041666666667 -78.17875000000001))
INFO:dem_handler.dem.cop_glo30:Number of cop30 files found intersecting bounds : 4
INFO:dem_handler.dem.cop_glo30:Local cop30m directory: /home/rtc_user/working/downloads/dem
INFO:dem_handler.dem.cop_glo30:Number of tiles existing locally : 0
INFO:dem_handler.dem.cop_glo30:Number of tiles missing locally : 4
INFO:dem_handler.download.aws:Downloading cop30m tile : Copernicus_DSM_COG_10_S78_00_E178_00_DEM/Copernicus_DSM_COG_10_S78_00_E178_00_DEM.tif, save location : /home/rtc_user/working/downloads/dem/Copernicus_DSM_COG_10_S78_00_E178_00_DEM/Copernicus_DSM_COG_10_S78_00_E178_00_DEM.tif
INFO:dem_handler.download.aws:Downloading cop30m tile : Copernicus_DSM_COG_10_S78_00_E179_00_DEM/Copernicus_DSM_COG_10_S78_00_E179_00_DEM.tif, save location : /home/rtc_user/working/downloads/dem/Copernicus_DSM_COG_10_S78_00_E179_00_DEM/Copernicus_DSM_COG_10_S78_00_E179_00_DEM.tif
INFO:dem_handler.download.aws:Downloading cop30m tile : Copernicus_DSM_COG_10_S79_00_E178_00_DEM/Copernicus_DSM_COG_10_S79_00_E178_00_DEM.tif, save location : /home/rtc_user/working/downloads/dem/Copernicus_DSM_COG_10_S79_00_E178_00_DEM/Copernicus_DSM_COG_10_S79_00_E178_00_DEM.tif
INFO:dem_handler.download.aws:Downloading cop30m tile : Copernicus_DSM_COG_10_S79_00_E179_00_DEM/Copernicus_DSM_COG_10_S79_00_E179_00_DEM.tif, save location : /home/rtc_user/working/downloads/dem/Copernicus_DSM_COG_10_S79_00_E179_00_DEM/Copernicus_DSM_COG_10_S79_00_E179_00_DEM.tif
INFO:dem_handler.dem.cop_glo30:4 tiles found in bounds
INFO:dem_handler.dem.cop_glo30:/home/rtc_user/working/downloads/dem/Copernicus_DSM_COG_10_S78_00_E178_00_DEM/Copernicus_DSM_COG_10_S78_00_E178_00_DEM.tif
INFO:dem_handler.dem.cop_glo30:/home/rtc_user/working/downloads/dem/Copernicus_DSM_COG_10_S78_00_E179_00_DEM/Copernicus_DSM_COG_10_S78_00_E179_00_DEM.tif
INFO:dem_handler.dem.cop_glo30:/home/rtc_user/working/downloads/dem/Copernicus_DSM_COG_10_S79_00_E178_00_DEM/Copernicus_DSM_COG_10_S79_00_E178_00_DEM.tif
INFO:dem_handler.dem.cop_glo30:/home/rtc_user/working/downloads/dem/Copernicus_DSM_COG_10_S79_00_E179_00_DEM/Copernicus_DSM_COG_10_S79_00_E179_00_DEM.tif
INFO:dem_handler.utils.spatial:Creating VRT
INFO:dem_handler.utils.spatial:VRT path = /home/rtc_user/working/downloads/dem/S1A_IW_SLC__1SDV_20191028T131928_20191028T131947_029659_0360CA_A1A0_dem_eastern.vrt
INFO:botocore.credentials:Found credentials in environment variables.
INFO:botocore.credentials:Found credentials in environment variables.
INFO:dem_handler.utils.spatial:Dem array shape = (8945, 1690)
INFO:root:Subtracting the geoid from the DEM to return ellipsoid heights
INFO:root:Downloading the egm_08 geoid
INFO:dem_handler.download.aws:Downloading egm_08 geoid for bounds (178.59208333333333, -78.17875000000001, 180.00041666666667, -75.69402777777778) from https://aria-geoid.s3.us-west-2.amazonaws.com/us_nga_egm2008_1_4326__agisoft.tif
INFO:botocore.credentials:Found credentials in environment variables.
WARNING:rasterio._env:CPLE_AppDefined in HTTP response code on https://aria-geoid.s3.us-west-2.amazonaws.com/us_nga_egm2008_1_4326__agisoft.tif.aux.xml: 403
WARNING:rasterio._env:CPLE_AppDefined in HTTP response code on https://aria-geoid.s3.us-west-2.amazonaws.com/us_nga_egm2008_1_4326__agisoft.aux: 403
WARNING:rasterio._env:CPLE_AppDefined in HTTP response code on https://aria-geoid.s3.us-west-2.amazonaws.com/us_nga_egm2008_1_4326__agisoft.AUX: 403
WARNING:rasterio._env:CPLE_AppDefined in HTTP response code on https://aria-geoid.s3.us-west-2.amazonaws.com/us_nga_egm2008_1_4326__agisoft.tif.aux: 403
WARNING:rasterio._env:CPLE_AppDefined in HTTP response code on https://aria-geoid.s3.us-west-2.amazonaws.com/us_nga_egm2008_1_4326__agisoft.tif.AUX: 403
WARNING:rasterio._env:CPLE_AppDefined in HTTP response code on https://aria-geoid.s3.us-west-2.amazonaws.com/us_nga_egm2008_1_4326__agisoft.xml: 403
WARNING:rasterio._env:CPLE_AppDefined in HTTP response code on https://aria-geoid.s3.us-west-2.amazonaws.com/us_nga_egm2008_1_4326__agisoft.XML: 403
INFO:botocore.credentials:Found credentials in environment variables.
INFO:botocore.credentials:Found credentials in environment variables.
WARNING:rasterio._env:CPLE_AppDefined in HTTP response code on https://aria-geoid.s3.us-west-2.amazonaws.com/us_nga_egm2008_1_4326__agisoft.tif.msk: 403
WARNING:rasterio._env:CPLE_AppDefined in HTTP response code on https://aria-geoid.s3.us-west-2.amazonaws.com/us_nga_egm2008_1_4326__agisoft.tif.MSK: 403
INFO:botocore.credentials:Found credentials in environment variables.
INFO:root:Using geoid file: /home/rtc_user/working/downloads/dem/S1A_IW_SLC__1SDV_20191028T131928_20191028T131947_029659_0360CA_A1A0_geoid.tif
INFO:botocore.credentials:Found credentials in environment variables.
INFO:botocore.credentials:Found credentials in environment variables.
INFO:botocore.credentials:Found credentials in environment variables.
INFO:botocore.credentials:Found credentials in environment variables.
INFO:botocore.credentials:Found credentials in environment variables.
INFO:botocore.credentials:Found credentials in environment variables.
INFO:botocore.credentials:Found credentials in environment variables.
INFO:botocore.credentials:Found credentials in environment variables.
INFO:dem_handler.dem.cop_glo30:Producing raster for Western Hemisphere bounds
INFO:dem_handler.dem.cop_glo30:Getting cop30m dem for bounds: (-180, -78.176201, -177.884048, -75.697151)
INFO:root:Adjusting bounds at high southern latitudes
INFO:dem_handler.dem.cop_glo30:Getting cop30m dem for adjusted bounds: (-180.0, -78.18420824376116, -177.43688072819896, -75.68750232378285)
(-180.0, -78.176201, -177.884048, -75.697151)
(-180.00041666666667, -78.18430555555555, -177.43625, -75.68736111111112)
INFO:dem_handler.dem.cop_glo30:Finding intersecting DEM files from: /home/rtc_user/miniconda3/envs/sar-pipeline/lib/python3.12/site-packages/dem_handler/data/copdem_tindex_filename.gpkg
POLYGON ((-177.43625 -78.18430555555555, -180.00041666666667 -78.18430555555555, -180.00041666666667 -75.68736111111112, -177.43625 -75.68736111111112, -177.43625 -78.18430555555555))
INFO:dem_handler.dem.cop_glo30:Number of cop30 files found intersecting bounds : 6
INFO:dem_handler.dem.cop_glo30:Local cop30m directory: /home/rtc_user/working/downloads/dem
INFO:dem_handler.dem.cop_glo30:Number of tiles existing locally : 0
INFO:dem_handler.dem.cop_glo30:Number of tiles missing locally : 6
INFO:dem_handler.download.aws:Downloading cop30m tile : Copernicus_DSM_COG_10_S78_00_W178_00_DEM/Copernicus_DSM_COG_10_S78_00_W178_00_DEM.tif, save location : /home/rtc_user/working/downloads/dem/Copernicus_DSM_COG_10_S78_00_W178_00_DEM/Copernicus_DSM_COG_10_S78_00_W178_00_DEM.tif
INFO:dem_handler.download.aws:Downloading cop30m tile : Copernicus_DSM_COG_10_S78_00_W179_00_DEM/Copernicus_DSM_COG_10_S78_00_W179_00_DEM.tif, save location : /home/rtc_user/working/downloads/dem/Copernicus_DSM_COG_10_S78_00_W179_00_DEM/Copernicus_DSM_COG_10_S78_00_W179_00_DEM.tif
INFO:dem_handler.download.aws:Downloading cop30m tile : Copernicus_DSM_COG_10_S78_00_W180_00_DEM/Copernicus_DSM_COG_10_S78_00_W180_00_DEM.tif, save location : /home/rtc_user/working/downloads/dem/Copernicus_DSM_COG_10_S78_00_W180_00_DEM/Copernicus_DSM_COG_10_S78_00_W180_00_DEM.tif
INFO:dem_handler.download.aws:Downloading cop30m tile : Copernicus_DSM_COG_10_S79_00_W178_00_DEM/Copernicus_DSM_COG_10_S79_00_W178_00_DEM.tif, save location : /home/rtc_user/working/downloads/dem/Copernicus_DSM_COG_10_S79_00_W178_00_DEM/Copernicus_DSM_COG_10_S79_00_W178_00_DEM.tif
INFO:dem_handler.download.aws:Downloading cop30m tile : Copernicus_DSM_COG_10_S79_00_W179_00_DEM/Copernicus_DSM_COG_10_S79_00_W179_00_DEM.tif, save location : /home/rtc_user/working/downloads/dem/Copernicus_DSM_COG_10_S79_00_W179_00_DEM/Copernicus_DSM_COG_10_S79_00_W179_00_DEM.tif
INFO:dem_handler.download.aws:Downloading cop30m tile : Copernicus_DSM_COG_10_S79_00_W180_00_DEM/Copernicus_DSM_COG_10_S79_00_W180_00_DEM.tif, save location : /home/rtc_user/working/downloads/dem/Copernicus_DSM_COG_10_S79_00_W180_00_DEM/Copernicus_DSM_COG_10_S79_00_W180_00_DEM.tif
INFO:dem_handler.dem.cop_glo30:6 tiles found in bounds
INFO:dem_handler.dem.cop_glo30:/home/rtc_user/working/downloads/dem/Copernicus_DSM_COG_10_S78_00_W178_00_DEM/Copernicus_DSM_COG_10_S78_00_W178_00_DEM.tif
INFO:dem_handler.dem.cop_glo30:/home/rtc_user/working/downloads/dem/Copernicus_DSM_COG_10_S78_00_W179_00_DEM/Copernicus_DSM_COG_10_S78_00_W179_00_DEM.tif
INFO:dem_handler.dem.cop_glo30:/home/rtc_user/working/downloads/dem/Copernicus_DSM_COG_10_S78_00_W180_00_DEM/Copernicus_DSM_COG_10_S78_00_W180_00_DEM.tif
INFO:dem_handler.dem.cop_glo30:/home/rtc_user/working/downloads/dem/Copernicus_DSM_COG_10_S79_00_W178_00_DEM/Copernicus_DSM_COG_10_S79_00_W178_00_DEM.tif
INFO:dem_handler.dem.cop_glo30:/home/rtc_user/working/downloads/dem/Copernicus_DSM_COG_10_S79_00_W179_00_DEM/Copernicus_DSM_COG_10_S79_00_W179_00_DEM.tif
INFO:dem_handler.dem.cop_glo30:/home/rtc_user/working/downloads/dem/Copernicus_DSM_COG_10_S79_00_W180_00_DEM/Copernicus_DSM_COG_10_S79_00_W180_00_DEM.tif
INFO:dem_handler.utils.spatial:Creating VRT
INFO:dem_handler.utils.spatial:VRT path = /home/rtc_user/working/downloads/dem/S1A_IW_SLC__1SDV_20191028T131928_20191028T131947_029659_0360CA_A1A0_dem_western.vrt
INFO:botocore.credentials:Found credentials in environment variables.
INFO:botocore.credentials:Found credentials in environment variables.
INFO:dem_handler.utils.spatial:Dem array shape = (8989, 3077)
INFO:root:Subtracting the geoid from the DEM to return ellipsoid heights
INFO:root:Using geoid file: /home/rtc_user/working/downloads/dem/S1A_IW_SLC__1SDV_20191028T131928_20191028T131947_029659_0360CA_A1A0_geoid.tif
INFO:botocore.credentials:Found credentials in environment variables.
Traceback (most recent call last):
  File "/home/rtc_user/miniconda3/envs/sar-pipeline/lib/python3.12/site-packages/rasterio/mask.py", line 80, in raster_geometry_mask
    window = geometry_window(dataset, shapes, pad_x=pad_x, pad_y=pad_y)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rtc_user/miniconda3/envs/sar-pipeline/lib/python3.12/site-packages/rasterio/features.py", line 507, in geometry_window
    window = window.intersection(raster_window)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rtc_user/miniconda3/envs/sar-pipeline/lib/python3.12/site-packages/rasterio/windows.py", line 785, in intersection
    return intersection([self, other])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rtc_user/miniconda3/envs/sar-pipeline/lib/python3.12/site-packages/rasterio/windows.py", line 125, in wrapper
    return function(*args[0])
           ^^^^^^^^^^^^^^^^^^
  File "/home/rtc_user/miniconda3/envs/sar-pipeline/lib/python3.12/site-packages/rasterio/windows.py", line 239, in intersection
    return functools.reduce(_intersection, windows)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rtc_user/miniconda3/envs/sar-pipeline/lib/python3.12/site-packages/rasterio/windows.py", line 257, in _intersection
    raise WindowError(f"Intersection is empty {w1} {w2}")
rasterio.errors.WindowError: Intersection is empty Window(col_off=-21518, row_off=-3, width=159, height=155) Window(col_off=0, row_off=0, width=85, height=150)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/rtc_user/miniconda3/envs/sar-pipeline/bin/get-data-for-scene-and-make-run-config", line 8, in <module>
    sys.exit(get_data_for_scene_and_make_run_config())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rtc_user/miniconda3/envs/sar-pipeline/lib/python3.12/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rtc_user/miniconda3/envs/sar-pipeline/lib/python3.12/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/rtc_user/miniconda3/envs/sar-pipeline/lib/python3.12/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rtc_user/miniconda3/envs/sar-pipeline/lib/python3.12/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rtc_user/sar-pipeline/sar_pipeline/aws/cli.py", line 204, in get_data_for_scene_and_make_run_config
    get_cop30_dem_for_bounds(
  File "/home/rtc_user/miniconda3/envs/sar-pipeline/lib/python3.12/site-packages/dem_handler/dem/cop_glo30.py", line 108, in get_cop30_dem_for_bounds
    western_output = get_cop30_dem_for_bounds(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rtc_user/miniconda3/envs/sar-pipeline/lib/python3.12/site-packages/dem_handler/dem/cop_glo30.py", line 240, in get_cop30_dem_for_bounds
    dem_array = remove_geoid(
                ^^^^^^^^^^^^^
  File "/home/rtc_user/miniconda3/envs/sar-pipeline/lib/python3.12/site-packages/dem_handler/dem/geoid.py", line 78, in remove_geoid
    geoid_array, geoid_transform = rasterio.mask.mask(
                                   ^^^^^^^^^^^^^^^^^^^
  File "/home/rtc_user/miniconda3/envs/sar-pipeline/lib/python3.12/site-packages/rasterio/mask.py", line 180, in mask
    shape_mask, transform, window = raster_geometry_mask(
                                    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/rtc_user/miniconda3/envs/sar-pipeline/lib/python3.12/site-packages/rasterio/mask.py", line 86, in raster_geometry_mask
    raise ValueError('Input shapes do not overlap raster.')
ValueError: Input shapes do not overlap raster.
Process failed: get-data-for-scene-and-make-run-config
(base) [ec2-user@ip-10-0-15-59 sar-pipeline]$ 

````