### PR TITLE
AM merge fix

### DIFF
--- a/dem_handler/dem/cop_glo30.py
+++ b/dem_handler/dem/cop_glo30.py
@@ -148,8 +148,8 @@ def get_cop30_dem_for_bounds(
 
         logging.info(f"Merging across antimeridian")
         dem_array, dem_profile = merge_arrays_with_geometadata(
-            arrays=[eastern_dem, western_dem],
-            profiles=[eastern_profile, western_profile],
+            arrays=[western_dem, eastern_dem],
+            profiles=[western_profile, eastern_profile],
             method="max",
             output_path=save_path,
         )


### PR DESCRIPTION
- Merge issues identified at the Antimeridian. A stip of ellipsoid heights was being placed along the merge, even with the 'max' method specified when merging east and west dems.
![Screenshot 2025-05-02 at 9 33 22 AM](https://github.com/user-attachments/assets/5f75ec70-53e3-47ac-bb46-2d57c64ef855)
- Testing showed that the method provided didn't change the values in the dem (e.g. 'min', 'first', 'last'). 
- Solution is to change the ordering of the dems passed into the merge. Checking the original tiles showed that the west is the one that extends slightly passed the AM and should therefore be set as the first anyway.
![Screenshot 2025-05-02 at 9 40 00 AM](https://github.com/user-attachments/assets/5813a13c-220c-45c6-a17e-98ecce913019)
![Screenshot 2025-05-02 at 10 26 05 AM](https://github.com/user-attachments/assets/561f73a5-8553-4346-81ee-8c0b78602fee)
![Screenshot 2025-05-02 at 10 28 28 AM](https://github.com/user-attachments/assets/3044cd2d-3e28-45a5-b638-4f5c49291a6b)

