### PR TITLE
Upgrade/rema

### DIFF
--- a/dem_handler/dem/cop_glo30.py
+++ b/dem_handler/dem/cop_glo30.py
@@ -25,6 +25,7 @@ from dem_handler.utils.raster import (
     adjust_pixel_coordinate_from_point_to_area,
     expand_bounding_box_to_pixel_edges,
 )
+from dem_handler.utils.general import log_timing
 from dem_handler.dem.geoid import apply_geoid
 from dem_handler.download.aws import download_cop_glo30_tiles, download_egm_08_geoid
 
@@ -37,6 +38,7 @@ DATA_DIR = Path(__file__).parents[1] / Path("data")
 COP30_GPKG_PATH = DATA_DIR / Path("copdem_tindex_filename.gpkg")
 
 
+@log_timing
 def get_cop30_dem_for_bounds(
     bounds: BBox,
     save_path: Path,

--- a/dem_handler/dem/cop_glo30.py
+++ b/dem_handler/dem/cop_glo30.py
@@ -25,7 +25,7 @@ from dem_handler.utils.raster import (
     adjust_pixel_coordinate_from_point_to_area,
     expand_bounding_box_to_pixel_edges,
 )
-from dem_handler.dem.geoid import remove_geoid
+from dem_handler.dem.geoid import apply_geoid
 from dem_handler.download.aws import download_cop_glo30_tiles, download_egm_08_geoid
 
 logger = logging.getLogger(__name__)
@@ -159,6 +159,9 @@ def get_cop30_dem_for_bounds(
     else:
         # Adjust bounds at high latitude if requested
         if adjust_at_high_lat:
+            logger.info(
+                f"Adjusting bounds at high latitude, this may return additional data than requested"
+            )
             adjusted_bounds = adjust_bounds_at_high_lat(bounds)
             logger.info(
                 f"Getting cop30m dem for adjusted bounds: {adjusted_bounds.bounds}"
@@ -174,12 +177,12 @@ def get_cop30_dem_for_bounds(
                 pixel_buffer=buffer_pixels,
                 degree_buffer=buffer_degrees,
             )
+            logger.info(f"Getting cop30m dem for buffered bounds : {adjusted_bounds}")
 
         # Before continuing, check that the new bounds for the dem cover the original bounds
         adjusted_bounds_polygon = shapely.geometry.box(*adjusted_bounds.bounds)
         bounds_polygon = shapely.geometry.box(*bounds.bounds)
         bounds_filled_by_dem = bounds_polygon.within(adjusted_bounds_polygon)
-        print(bounds_polygon.bounds)
         if not bounds_filled_by_dem:
             warn_msg = (
                 "The Cop30 DEM bounds do not fully cover the requested bounds. "
@@ -195,7 +198,6 @@ def get_cop30_dem_for_bounds(
         adjusted_bounds, adjusted_bounds_profile = (
             make_empty_cop_glo30_profile_for_bounds(adjusted_bounds)
         )
-        print(adjusted_bounds.bounds)
         # Find cop glo30 paths for bounds
         logger.info(f"Finding intersecting DEM files from: {cop30_index_path}")
         dem_paths = find_required_dem_paths_from_index(
@@ -238,9 +240,7 @@ def get_cop30_dem_for_bounds(
             )
 
         if ellipsoid_heights:
-            logging.info(
-                f"Subtracting the geoid from the DEM to return ellipsoid heights"
-            )
+            logging.info(f"Returning DEM referenced to ellipsoidal heights")
             if not download_geoid and not Path(geoid_tif_path).exists():
                 raise FileExistsError(
                     f"Geoid file does not exist: {geoid_tif_path}. "
@@ -266,14 +266,19 @@ def get_cop30_dem_for_bounds(
                     download_egm_08_geoid(geoid_tif_path, bounds=adjusted_bounds.bounds)
 
             logging.info(f"Using geoid file: {geoid_tif_path}")
-            dem_array = remove_geoid(
+            dem_array = apply_geoid(
                 dem_array=dem_array,
                 dem_profile=dem_profile,
                 geoid_path=geoid_tif_path,
                 buffer_pixels=2,
                 save_path=save_path,
+                method="add",
             )
 
+        else:
+            logging.info(f"Returning DEM referenced to geoid heights")
+
+        logging.info(f"Dem array shape = {dem_array.shape}")
         return dem_array, dem_profile, dem_paths
 
 

--- a/dem_handler/dem/rema.py
+++ b/dem_handler/dem/rema.py
@@ -184,8 +184,8 @@ def get_rema_dem_for_bounds(
     )
 
     # return the dem in either ellipsoid or geoid referenced heights. The REMA dem is already
-    # referenced to the ellipsoid. Values are set to zero where no tile data exists (e.g. over water)
-    # create a mask for this area
+    # referenced to the ellipsoid. Values are set to zero where no tile data exists
+    # create a mask for this area so we can apply the geoid here to convert to ellipsoid heights
     dem_novalues_mask = dem_array == 0
     dem_novalues_count = np.count_nonzero(dem_novalues_mask)
     dem_values_mask = dem_array != 0
@@ -225,9 +225,10 @@ def get_rema_dem_for_bounds(
             method="add",
         )
     else:
-        # heights are not referenced to the ellipsoid, therefore we must
+        # heights are not referenced to the geoid, therefore we must
         # convert ellipsoid referenced heights to geoid referenced heights as the
-        # rema dem is by default referenced to the ellipsoid
+        # rema dem is by default referenced to the ellipsoid. We do this only in
+        # areas with data, leaving the nodata areas at zero values
         logging.info(f"Returning DEM referenced to geoid heights")
         dem_array = apply_geoid(
             dem_array=dem_array,

--- a/dem_handler/dem/rema.py
+++ b/dem_handler/dem/rema.py
@@ -10,6 +10,7 @@ from dem_handler.utils.spatial import (
     transform_polygon,
     crop_datasets_to_bounds,
 )
+from dem_handler.utils.general import log_timing
 from dem_handler.download.aws import download_rema_tiles, extract_s3_path
 
 from dem_handler.dem.geoid import apply_geoid
@@ -28,6 +29,7 @@ REMA_VALID_RESOLUTIONS = [
 ]  # [2, 10, 32, 100, 500, 1000] It seems there are no higher resolutions in the new index
 
 
+@log_timing
 def get_rema_dem_for_bounds(
     bounds: BBox,
     save_path: Path | str = "",

--- a/dem_handler/download/aio_aws.py
+++ b/dem_handler/download/aio_aws.py
@@ -9,6 +9,11 @@ import multiprocess as mp
 import glob
 
 
+import logging
+
+logger = logging.getLogger(__name__)
+
+
 async def download_dem_tile(
     tile_object: Path,
     save_folder: Path,
@@ -36,7 +41,7 @@ async def download_dem_tile(
     async with session.resource("s3", config=config) as s3:
         bucket = await s3.Bucket(bucket_name)
         save_path = save_folder / tile_object.name
-        print(
+        logger.info(
             f"Downloading dem tile : {tile_object.as_posix()}, save location : {save_path.as_posix()}"
         )
         try:
@@ -74,7 +79,7 @@ async def upload_dem_tile(
         config=config,
     ) as s3:
         bucket = await s3.Bucket(bucket_name)
-        print(
+        logger.info(
             f"Uploading dem tile : {local_path.as_posix()}, s3 location : {tile_object.as_posix()}"
         )
         try:

--- a/dem_handler/download/aws.py
+++ b/dem_handler/download/aws.py
@@ -168,7 +168,7 @@ def extract_s3_path(url: str) -> str:
     # Check if the request was successful
     if response.status_code != 200:
         # Parse JSON content into a Python dictionary
-        print(
+        logger.info(
             f"Failed to retrieve data for {os.path.splitext(os.path.basename(json_url))[0]}. Status code: {response.status_code}"
         )
         return ""
@@ -237,11 +237,11 @@ def download_rema_tiles(
             local_folder = local_path.parent
             # check if the dem.tif already exists
             if local_path.is_file():
-                print(f"{local_path} already exists, skipping download")
+                logger.info(f"{local_path} already exists, skipping download")
                 dem_paths.append(local_path)
                 continue
             local_folder.mkdir(parents=True, exist_ok=True)
-            print(
+            logger.info(
                 f"downloading {i+1} of {len(dem_urls)}: src: {dem_url} dst: {local_path}"
             )
             urlretrieve(dem_url, local_path)

--- a/dem_handler/utils/general.py
+++ b/dem_handler/utils/general.py
@@ -1,0 +1,45 @@
+import time
+import logging
+from functools import wraps
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def log_timing(func):
+    """
+    Decorator that logs the execution time of a function.
+
+    Parameters
+    ----------
+    func : callable
+        The function whose execution time is to be measured and logged.
+
+    Returns
+    -------
+    callable
+        A wrapper function that executes the original function and logs the elapsed time in seconds.
+
+    Notes
+    -----
+    This decorator uses the `logging` module to log the execution time at the INFO level.
+    The log message format is: "timing : <function_name> : <elapsed_time>s".
+
+    Examples
+    --------
+    @log_timing
+    def slow_function():
+        time.sleep(2)
+    > slow_function()
+    > timing : slow_function : 2.00s
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        start = time.time()
+        result = func(*args, **kwargs)
+        elapsed = time.time() - start
+        logger.info(f"timing : {func.__name__} : {elapsed:.2f}s")
+        return result
+
+    return wrapper

--- a/dem_handler/utils/spatial.py
+++ b/dem_handler/utils/spatial.py
@@ -408,7 +408,6 @@ def crop_datasets_to_bounds(
         # Using the masking adds an extra dimension from the read
         # Remove this by squeezing before writing
         dem_array = dem_array.squeeze()
-        logger.info(f"Dem array shape = {dem_array.shape}")
 
         dem_profile = src.profile
         dem_profile.update(

--- a/tests/rema/test_dem_rema.py
+++ b/tests/rema/test_dem_rema.py
@@ -1,6 +1,6 @@
 from dem_handler.dem.rema import get_rema_dem_for_bounds, BBox
 from dem_handler.utils.spatial import resize_bounds, BoundingBox, transform_polygon
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 import rasterio as rio
 from numpy.testing import assert_allclose
 import pytest
@@ -11,151 +11,147 @@ from shapely import box
 
 
 CURRENT_DIR = Path(__file__).parent.resolve()
-TEST_PATH = CURRENT_DIR.parent
-GEOID_PATH = TEST_PATH / "data/geoid/egm_08_geoid.tif"
+TEST_DATA_PATH = CURRENT_DIR.parent
 REMA_INDEX_PATH = CURRENT_DIR / "data/REMA_Mosaic_Index_v2_gpkg.gpkg"
+GEOID_DATA_PATH = TEST_DATA_PATH / "data" / "geoid"
 TMP_PATH = CURRENT_DIR / "TMP"
 TEST_DATA_PATH = CURRENT_DIR / "data"
 
 
+# data for tests is downloaded with download_test_data.py script
 @dataclass
 class TestDem:
     requested_bounds: BBox
-    bounds_array_file: str
+    dem_file: str
     resolution: int
     num_tasks: int | None
+    geoid: Path
+    ellipsoid_heights: bool
 
 
-dem_name = "38_48_1_2_32m_v2.0_dem.tif"
+# A single source tile
 bbox = BoundingBox(67.45, -72.55, 67.55, -72.45)
-test_single_tile = TestDem(
+test_single_tile_ellipsoid_h = TestDem(
     bbox,
-    os.path.join(TEST_DATA_PATH, dem_name),
+    os.path.join(TEST_DATA_PATH, "rema_38_48_1_2_32m_v2.0_dem_ellipsoid_h.tif"),
     32,
     None,
+    os.path.join(GEOID_DATA_PATH, "egm_08_geoid_rema_38_48_1_2_32m_v2.0_dem.tif"),
+    True,
 )
 
-dem_name = "rema_32m_four_tiles.tif"
-test_three_tiles = TestDem(
+test_four_tiles_ellipsoid_h = TestDem(
     resize_bounds(bbox, 10.0),
-    os.path.join(TEST_DATA_PATH, dem_name),
+    os.path.join(TEST_DATA_PATH, "rema_32m_four_tiles_ellipsoid_h.tif"),
     32,
     -1,
+    os.path.join(GEOID_DATA_PATH, "egm_08_geoid_rema_32m_four_tiles.tif"),
+    True,
 )
 
-
-dem_name = "rema_32m_two_tiles_ocean.tif"
+# over ocean where tile data exists
 ocean_bbox = BoundingBox(162.0, -70.95, 163.0, -69.83)
-test_four_tiles_ocean = TestDem(
+test_two_tiles_ocean_ellipsoid_h = TestDem(
     ocean_bbox,
-    os.path.join(TEST_DATA_PATH, dem_name),
+    os.path.join(TEST_DATA_PATH, "rema_32m_two_tiles_ocean_ellipsoid_h.tif"),
     32,
     None,
+    os.path.join(GEOID_DATA_PATH, "egm_08_geoid_rema_32m_two_tiles_ocean.tif"),
+    True,
 )
 
-test_dems = [
-    test_single_tile,
-    test_three_tiles,
-    test_four_tiles_ocean,
+# over land and ocean where tile data partially exists
+ocean_no_data_bbox = BoundingBox(165.75, -77.07, 167.40, -76.53)
+test_one_tile_and_no_tile_overlap_ellipsoid_h = TestDem(
+    ocean_no_data_bbox,
+    os.path.join(
+        TEST_DATA_PATH, "rema_32m_one_tile_and_no_tile_overlap_ellipsoid_h.tif"
+    ),
+    32,
+    None,
+    os.path.join(
+        GEOID_DATA_PATH, "egm_08_geoid_rema_32m_one_tile_and_no_tile_overlap.tif"
+    ),
+    True,
+)
+
+test_dems_ellipsoid = [
+    test_single_tile_ellipsoid_h,
+    test_four_tiles_ellipsoid_h,
+    test_two_tiles_ocean_ellipsoid_h,
+    test_one_tile_and_no_tile_overlap_ellipsoid_h,
+]
+
+# make the geoid test set
+# reference the geoid files instead of the ellipsoid ones
+test_single_tile_geoid_h = replace(
+    test_single_tile_ellipsoid_h,
+    dem_file=test_single_tile_ellipsoid_h.dem_file.replace("ellipsoid", "geoid"),
+    ellipsoid_heights=False,
+)
+test_four_tiles_geoid_h = replace(
+    test_four_tiles_ellipsoid_h,
+    dem_file=test_four_tiles_ellipsoid_h.dem_file.replace("ellipsoid", "geoid"),
+    ellipsoid_heights=False,
+)
+test_two_tiles_ocean_geoid_h = replace(
+    test_two_tiles_ocean_ellipsoid_h,
+    dem_file=test_two_tiles_ocean_ellipsoid_h.dem_file.replace("ellipsoid", "geoid"),
+    ellipsoid_heights=False,
+)
+test_one_tile_and_no_tile_overlap_geoid_h = replace(
+    test_one_tile_and_no_tile_overlap_ellipsoid_h,
+    dem_file=test_one_tile_and_no_tile_overlap_ellipsoid_h.dem_file.replace(
+        "ellipsoid", "geoid"
+    ),
+    ellipsoid_heights=False,
+)
+
+test_dems_geoid = [
+    test_single_tile_geoid_h,
+    test_four_tiles_geoid_h,
+    test_two_tiles_ocean_geoid_h,
+    test_one_tile_and_no_tile_overlap_geoid_h,
 ]
 
 
-@pytest.mark.parametrize("test_input", test_dems)
-def test_rema_dem_for_bounds_ocean_and_land(test_input: TestDem):
+@pytest.mark.parametrize("test_input", test_dems_ellipsoid + test_dems_geoid)
+def test_rema_dem_for_bounds(test_input: TestDem):
 
     bounds = test_input.requested_bounds
-    bounds_array_file = test_input.bounds_array_file
+    dem_file = test_input.dem_file
     resolution = test_input.resolution
     num_tasks = test_input.num_tasks
+    geoid_path = test_input.geoid
+    ellipsoid_heights = test_input.ellipsoid_heights
+
+    expected_dem_name = Path(dem_file).name
 
     if not TMP_PATH.exists():
         TMP_PATH.mkdir(parents=True, exist_ok=True)
 
+    SAVE_PATH = TMP_PATH / Path(f"{expected_dem_name}")
     array, profile, _ = get_rema_dem_for_bounds(
         bounds,
-        save_path=TMP_PATH / Path("TMP.tif"),
+        save_path=SAVE_PATH,
         rema_index_path=REMA_INDEX_PATH,
         resolution=resolution,
         bounds_src_crs=4326,
-        ellipsoid_heights=False,
+        ellipsoid_heights=ellipsoid_heights,
         num_tasks=num_tasks,
-        geoid_tif_path=GEOID_PATH,
+        geoid_tif_path=geoid_path,
+        download_geoid=False,
     )
 
-    with rio.open(bounds_array_file, "r") as src:
+    with rio.open(dem_file, "r") as src:
         expected_array = src.read(1)
 
     assert_allclose(array, expected_array)
 
-    with rio.open(str(TMP_PATH / Path("TMP.tif"))) as src:
+    with rio.open(SAVE_PATH) as src:
         array = src.read(1)
 
     assert_allclose(array, expected_array)
 
     # Once complete, remove the TMP files and directory
     shutil.rmtree(TMP_PATH)
-
-
-def test_rema_dem_for_psg_bounds():
-    psg_bbox = BoundingBox(*transform_polygon(box(*bbox.bounds), 4326, 3031).bounds)
-    dem_name = "rema_32m_four_tiles_psg.tif"
-    bounds_array_file = os.path.join(TEST_DATA_PATH, dem_name)
-
-    if not TMP_PATH.exists():
-        TMP_PATH.mkdir(parents=True, exist_ok=True)
-
-    array, _, _ = get_rema_dem_for_bounds(
-        resize_bounds(psg_bbox, 10.0),
-        save_path=TMP_PATH / Path("TMP.tif"),
-        rema_index_path=REMA_INDEX_PATH,
-        resolution=32,
-        ellipsoid_heights=False,
-        geoid_tif_path=GEOID_PATH,
-    )
-
-    with rio.open(bounds_array_file, "r") as src:
-        expected_array = src.read(1)
-
-    assert_allclose(array, expected_array)
-
-    with rio.open(str(TMP_PATH / Path("TMP.tif"))) as src:
-        array = src.read(1)
-
-    assert_allclose(array, expected_array)
-
-    # Once complete, remove the TMP files and directory
-    shutil.rmtree(TMP_PATH)
-
-
-# REMA is already in ellipsoid heights, so this test is not needed
-# We should fix the function to transform REMA to geoid heights instead of the other way around
-# def test_rema_dem_for_bounds_ocean_and_land_ellipsoid():
-
-#     dem_name = "38_48_1_2_32m_v2.0_dem_ellipsoid.tif"
-#     bbox = BoundingBox(67.45, -72.55, 67.55, -72.45)
-#     bounds_array_file = os.path.join(TEST_DATA_PATH, dem_name)
-
-#     if not TMP_PATH.exists():
-#         TMP_PATH.mkdir(parents=True, exist_ok=True)
-
-#     array, _, _ = get_rema_dem_for_bounds(
-#         bbox,
-#         save_path=TMP_PATH / Path("TMP.tif"),
-#         rema_index_path=REMA_INDEX_PATH,
-#         resolution=32,
-#         bounds_src_crs=4326,
-#         geoid_tif_path=GEOID_PATH,
-#     )
-
-#     with rio.open(bounds_array_file, "r") as src:
-#         expected_array = src.read(1)
-
-#     assert_allclose(array, expected_array)
-
-#     with rio.open(str(TMP_PATH / Path("TMP.tif"))) as src:
-#         array = src.read(1)
-
-#     assert_allclose(array, expected_array)
-
-#     # Once complete, remove the TMP files and directory
-#     shutil.rmtree(TMP_PATH)

--- a/tests/rema/test_dem_rema.py
+++ b/tests/rema/test_dem_rema.py
@@ -79,6 +79,7 @@ def test_rema_dem_for_bounds_ocean_and_land(test_input: TestDem):
         bounds_src_crs=4326,
         ellipsoid_heights=False,
         num_tasks=num_tasks,
+        geoid_tif_path=GEOID_PATH,
     )
 
     with rio.open(bounds_array_file, "r") as src:
@@ -109,6 +110,7 @@ def test_rema_dem_for_psg_bounds():
         rema_index_path=REMA_INDEX_PATH,
         resolution=32,
         ellipsoid_heights=False,
+        geoid_tif_path=GEOID_PATH,
     )
 
     with rio.open(bounds_array_file, "r") as src:


### PR DESCRIPTION
- Enable passing of both string and path types
- Enable buffer specified in metres or pixels
- Fix logic to reference either the geoid or ellipsoid by applying the geoid file. A mask is used to apply this in some areas only depending on where rema data exists for tiles. 
- Add logging the time it takes functions to run
- Update tests with files for both geoid and ellipsoid heights
- Add logic to check if the geoid covers the dem before subtracting