### PR TITLE
Bugfix/rema bounds

### DIFF
--- a/dem_handler/dem/rema.py
+++ b/dem_handler/dem/rema.py
@@ -12,7 +12,6 @@ from dem_handler.utils.spatial import (
     BoundingBox,
     transform_polygon,
     crop_datasets_to_bounds,
-    adjust_bounds,
 )
 from dem_handler.utils.general import log_timing
 from dem_handler.download.aws import download_rema_tiles, extract_s3_path
@@ -130,7 +129,6 @@ def get_rema_dem_for_bounds(
             f"Transforming bounds from {bounds_src_crs} to {REMA_CRS}. This may return data beyond the requested bounds. If this is not desired, provide the bounds in EPSG:{REMA_CRS}."
         )
         # first adjust the bounds to account for warping between original and target crs
-        bounds = adjust_bounds(bounds, src_crs=bounds_src_crs, ref_crs=REMA_CRS)
         bounds = BoundingBox(
             *transform_polygon(box(*bounds.bounds), bounds_src_crs, REMA_CRS).bounds
         )

--- a/dem_handler/dem/rema.py
+++ b/dem_handler/dem/rema.py
@@ -128,7 +128,6 @@ def get_rema_dem_for_bounds(
         logging.warning(
             f"Transforming bounds from {bounds_src_crs} to {REMA_CRS}. This may return data beyond the requested bounds. If this is not desired, provide the bounds in EPSG:{REMA_CRS}."
         )
-        # first adjust the bounds to account for warping between original and target crs
         bounds = BoundingBox(
             *transform_polygon(box(*bounds.bounds), bounds_src_crs, REMA_CRS).bounds
         )

--- a/tests/rema/test_dem_rema.py
+++ b/tests/rema/test_dem_rema.py
@@ -140,6 +140,8 @@ def test_rema_dem_for_bounds(test_input: TestDem):
         num_tasks=num_tasks,
         geoid_tif_path=geoid_path,
         download_geoid=False,
+        # download_geoid=True, # uncomment to make new test data in TMP folder
+        # geoid_tif_path=TMP_PATH / Path(geoid_path).name # uncomment to make new test data in TMP folder
     )
 
     with rio.open(dem_file, "r") as src:


### PR DESCRIPTION
- Reverting logic to Amir's original handling of coordinate conversions. The added `adjust_bounds` function is a double up on the next line. Essentially the bounds were being adjusted twice resulting in a much larger box than required.
- Updated tests and provided a couple hinting comments incase the data needs to be easily generated again.