### PR TITLE
Upgrade/rema return over ocean

### DIFF
--- a/dem_handler/dem/cop_glo30.py
+++ b/dem_handler/dem/cop_glo30.py
@@ -631,8 +631,6 @@ def make_empty_cop_glo30_profile_for_bounds(
     ----------
     bounds : BoundingBox | tuple[float | int, float | int, float | int, float | int]
         The set of bounds (left, bottom, right, top)
-    pixel_buffer | int
-        The number of pixels to add as a buffer to the profile
 
     Returns
     -------

--- a/tests/rema/test_dem_rema.py
+++ b/tests/rema/test_dem_rema.py
@@ -61,6 +61,18 @@ test_one_tile_ocean_ellipsoid_h = TestDem(
     True,
 )
 
+# over ocean where no tile intersections exists
+no_tile_intersection_bbox = BoundingBox(143.0, -63.0, 143.5, -62.5)
+test_no_intersection_ellipsoid_h = TestDem(
+    no_tile_intersection_bbox,
+    os.path.join(TEST_DATA_PATH, "rema_32m_no_tile_intersection_ellipsoid_h.tif"),
+    32,
+    None,
+    os.path.join(GEOID_DATA_PATH, "egm_08_geoid_rema_32m_no_tile_intersection.tif"),
+    True,
+)
+
+
 # over land and ocean where tile data partially exists
 ocean_no_data_bbox = BoundingBox(166.8, -77.0, 167.0, -76.7)
 test_one_tile_and_no_tile_overlap_ellipsoid_h = TestDem(

--- a/tests/rema/test_dem_rema.py
+++ b/tests/rema/test_dem_rema.py
@@ -72,7 +72,6 @@ test_no_intersection_ellipsoid_h = TestDem(
     True,
 )
 
-
 # over land and ocean where tile data partially exists
 ocean_no_data_bbox = BoundingBox(166.8, -77.0, 167.0, -76.7)
 test_one_tile_and_no_tile_overlap_ellipsoid_h = TestDem(
@@ -92,6 +91,7 @@ test_dems_ellipsoid = [
     test_single_tile_ellipsoid_h,
     test_four_tiles_ellipsoid_h,
     test_one_tile_ocean_ellipsoid_h,
+    test_no_intersection_ellipsoid_h,
     test_one_tile_and_no_tile_overlap_ellipsoid_h,
 ]
 
@@ -112,6 +112,11 @@ test_one_tile_ocean_geoid_h = replace(
     dem_file=test_one_tile_ocean_ellipsoid_h.dem_file.replace("ellipsoid", "geoid"),
     ellipsoid_heights=False,
 )
+test_no_intersection_geoid_h = replace(
+    test_no_intersection_ellipsoid_h,
+    dem_file=test_no_intersection_ellipsoid_h.dem_file.replace("ellipsoid", "geoid"),
+    ellipsoid_heights=False,
+)
 test_one_tile_and_no_tile_overlap_geoid_h = replace(
     test_one_tile_and_no_tile_overlap_ellipsoid_h,
     dem_file=test_one_tile_and_no_tile_overlap_ellipsoid_h.dem_file.replace(
@@ -124,6 +129,7 @@ test_dems_geoid = [
     test_single_tile_geoid_h,
     test_four_tiles_geoid_h,
     test_one_tile_ocean_geoid_h,
+    test_no_intersection_geoid_h,
     test_one_tile_and_no_tile_overlap_geoid_h,
 ]
 


### PR DESCRIPTION
- Return a DEM even if no REMA tiles are intersected if `return_over_ocean = True`. Prior to this, no data was returned. 
- Adding a test case for over ocean / no tile intersections