### PR TITLE
30 pipeline rema antimeridian handling

### DIFF
--- a/dem_handler/dem/rema.py
+++ b/dem_handler/dem/rema.py
@@ -144,13 +144,14 @@ def get_rema_dem_for_bounds(
         dem_crosses_antimeridian = False
         # run a basic to check if the bounds likely cross the antimeridian but
         # are just formatted wrong. If so, warn the user.
-        if check_bounds_likely_cross_antimeridian(bounds):
-            logging.warning(
-                "Provided bounds have very large longitude extent. If the shape crosses the "
-                f"antimeridian, reformat the bounds as : ({bounds[2]}, {bounds[1]}, {bounds[0]}, {bounds[3]}). "
-                "For large areas, provide the inputs bounds in 3031 to avoid transform errors between "
-                "coordinate systems."
-            )
+        if bounds_src_crs == 4326:
+            if check_bounds_likely_cross_antimeridian(bounds):
+                logging.warning(
+                    "Provided bounds have very large longitude extent. If the shape crosses the "
+                    f"antimeridian, reformat the bounds as : ({bounds[2]}, {bounds[1]}, {bounds[0]}, {bounds[3]}). "
+                    "For large areas, provide the inputs bounds in 3031 to avoid transform errors between "
+                    "coordinate systems."
+                )
 
     if bounds_src_crs != REMA_CRS:
         logging.warning(

--- a/dem_handler/dem/rema.py
+++ b/dem_handler/dem/rema.py
@@ -258,10 +258,10 @@ def get_rema_dem_for_bounds(
             )
             # separate the geoid into east and west sections
             east_geoid_tif_path = geoid_tif_path.with_stem(
-                geoid_tif_path.stem + "_east"
+                geoid_tif_path.stem + "_eastern"
             )
             west_geoid_tif_path = geoid_tif_path.with_stem(
-                geoid_tif_path.stem + "_west"
+                geoid_tif_path.stem + "_western"
             )
             # construct the bounds for east and west hemisphere
             east_geoid_bounds, west_geoid_bounds = (
@@ -278,7 +278,7 @@ def get_rema_dem_for_bounds(
             ]
         else:
             geoid_tifs_to_apply = [geoid_tif_path]
-            geoid_bounds_to_apply = [geoid_bounds]
+            geoid_bounds_to_apply = [geoid_bounds]  # bounds already tuple
 
         if not download_geoid and not all(p.exists() for p in geoid_tifs_to_apply):
             raise FileExistsError(
@@ -310,7 +310,7 @@ def get_rema_dem_for_bounds(
 
     if geoid_crosses_antimeridian:
         logging.info(
-            f"Reprojecting and merge east and west hemisphere geoid rasters to EPSG:{REMA_CRS}"
+            f"Reproject and merge east and west hemisphere geoid rasters to EPSG:{REMA_CRS}"
         )
         reproject_and_merge_rasters(
             geoid_tifs_to_apply, REMA_CRS, save_path=geoid_tif_path
@@ -319,6 +319,9 @@ def get_rema_dem_for_bounds(
     if ellipsoid_heights:
         logging.info(f"Returning DEM referenced to ellipsoidal heights")
         logging.info(f"Applying geoid to DEM : {geoid_tif_path}")
+        # Apply the geoid only on areas where no rema data was found
+        # i.e. these values were set to zero and will be replaced with
+        # ellipsoid heights
         dem_array = apply_geoid(
             dem_array=dem_array,
             dem_profile=dem_profile,

--- a/dem_handler/dem/rema.py
+++ b/dem_handler/dem/rema.py
@@ -315,6 +315,11 @@ def get_rema_dem_for_bounds(
         reproject_and_merge_rasters(
             geoid_tifs_to_apply, REMA_CRS, save_path=geoid_tif_path
         )
+        # add a larger buffer to ensure geoid is applied correctly to all of dem
+        dem_mask_buffer = 5_000
+    else:
+        # no buffer is required
+        dem_mask_buffer = 0
 
     if ellipsoid_heights:
         logging.info(f"Returning DEM referenced to ellipsoidal heights")
@@ -327,6 +332,7 @@ def get_rema_dem_for_bounds(
             dem_profile=dem_profile,
             geoid_path=geoid_tif_path,
             buffer_pixels=2,
+            dem_mask_buffer=dem_mask_buffer,
             save_path=save_path,
             mask_array=dem_novalues_mask,
             method="add",
@@ -343,6 +349,7 @@ def get_rema_dem_for_bounds(
             dem_profile=dem_profile,
             geoid_path=geoid_tif_path,
             buffer_pixels=2,
+            dem_mask_buffer=dem_mask_buffer,
             save_path=save_path,
             mask_array=dem_values_mask,
             method="subtract",

--- a/tests/rema/test_dem_rema.py
+++ b/tests/rema/test_dem_rema.py
@@ -87,12 +87,44 @@ test_one_tile_and_no_tile_overlap_ellipsoid_h = TestDem(
     True,
 )
 
+# antimeridian and no tile intersections
+antimeridian_no_intersection_bbox = BoundingBox(179.6, -71, -179.6, -70.6)
+test_antimeridian_no_intersection_ellipsoid_h = TestDem(
+    antimeridian_no_intersection_bbox,
+    os.path.join(
+        TEST_DATA_PATH, "rema_32m_antimeridian_no_intersection_ellipsoid_h.tif"
+    ),
+    32,
+    None,
+    os.path.join(
+        GEOID_DATA_PATH,
+        "egm_08_geoid_rema_32m_antimeridian_no_intersection.tif",
+    ),
+    True,
+)
+
+# antimeridian two tile intersect
+antimeridian_two_tile_bbox = BoundingBox(179.5, -78.5, -179.5, -78.1)
+test_antimeridian_two_tiles_ellipsoid_h = TestDem(
+    antimeridian_two_tile_bbox,
+    os.path.join(TEST_DATA_PATH, "rema_32m_antimeridian_two_tile_ellipsoid_h.tif"),
+    32,
+    None,
+    os.path.join(
+        GEOID_DATA_PATH,
+        "egm_08_geoid_rema_32m_antimeridian_two_tile.tif",
+    ),
+    True,
+)
+
 test_dems_ellipsoid = [
     test_single_tile_ellipsoid_h,
     test_four_tiles_ellipsoid_h,
     test_one_tile_ocean_ellipsoid_h,
     test_no_intersection_ellipsoid_h,
     test_one_tile_and_no_tile_overlap_ellipsoid_h,
+    test_antimeridian_no_intersection_ellipsoid_h,
+    test_antimeridian_two_tiles_ellipsoid_h,
 ]
 
 # make the geoid test set
@@ -124,6 +156,21 @@ test_one_tile_and_no_tile_overlap_geoid_h = replace(
     ),
     ellipsoid_heights=False,
 )
+test_antimeridian_no_intersection_geoid_h = replace(
+    test_antimeridian_no_intersection_ellipsoid_h,
+    dem_file=test_antimeridian_no_intersection_ellipsoid_h.dem_file.replace(
+        "ellipsoid", "geoid"
+    ),
+    ellipsoid_heights=False,
+)
+test_antimeridian_two_tiles_geoid_h = replace(
+    test_antimeridian_two_tiles_ellipsoid_h,
+    dem_file=test_antimeridian_two_tiles_ellipsoid_h.dem_file.replace(
+        "ellipsoid", "geoid"
+    ),
+    ellipsoid_heights=False,
+)
+
 
 test_dems_geoid = [
     test_single_tile_geoid_h,
@@ -131,6 +178,8 @@ test_dems_geoid = [
     test_one_tile_ocean_geoid_h,
     test_no_intersection_geoid_h,
     test_one_tile_and_no_tile_overlap_geoid_h,
+    test_antimeridian_no_intersection_geoid_h,
+    test_antimeridian_two_tiles_geoid_h,
 ]
 
 


### PR DESCRIPTION
- Logic to handle cases over the antimeridian
- The REMA dem is in 3031 and therefore does not require special logic over the antimeridian
- The challenge is the application of the geoid, which is in 4326 and therefore requires special logic to handle the east and west hemispheres separately.
- The code will now check if the geoid request covers the antimeridian. If so, two separate geoids will be downloaded. These will then be combined and reprojected to 3031 before being applied to the REMA DEM.
- Test cases have been added.