### PR TITLE
Address pytest warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,6 @@ repos:
     hooks:
       - id: black
         args: ["--exclude", ".pixi"]
-        language_version: python3.13
   - repo: local
     hooks:
     -   id: check-pixi-lock

--- a/dem_handler/dem/cop_glo30.py
+++ b/dem_handler/dem/cop_glo30.py
@@ -10,7 +10,6 @@ import rasterio
 import rasterio.mask
 import shapely.geometry
 from affine import Affine
-from osgeo import gdal
 from rasterio.crs import CRS
 
 from dem_handler.dem.geoid import apply_geoid

--- a/dem_handler/utils/raster.py
+++ b/dem_handler/utils/raster.py
@@ -10,6 +10,9 @@ import pyproj
 import rasterio
 from affine import Affine
 from osgeo import gdal
+
+gdal.UseExceptions()
+
 from pyproj import Transformer
 from rasterio.enums import Resampling
 from rasterio.io import MemoryFile

--- a/dem_handler/utils/spatial.py
+++ b/dem_handler/utils/spatial.py
@@ -13,6 +13,9 @@ import pyproj
 import rasterio
 import shapely
 from osgeo import gdal
+
+gdal.UseExceptions()
+
 from pyproj import CRS
 from pyproj.aoi import AreaOfInterest
 from pyproj.database import query_utm_crs_info

--- a/environment.yaml
+++ b/environment.yaml
@@ -5,9 +5,6 @@ channels:
 dependencies:
 - gdal >=3.10.2
 - rasterio >=1.4.3
-- pyogrio >=0.10.0
-- multiprocess >=0.70.17
-- aioboto3 ==14.1.0
 - python >=3.8
 - pip
 - pip:
@@ -15,3 +12,9 @@ dependencies:
   - boto3>=1.37.1
   - geopandas>=1.0.1
   - requests>=2.32.3
+  - aioboto3>=15.5.0, <16
+  - scikit-image>=0.26.0, <0.27
+  - multiprocess
+  - pyogrio>=0.13.0, <0.14
+  - pooch>=1.9.0, <2
+  - tqdm>=4.70.0, <5

--- a/tests/cop_glo30/test_dem_cop.py
+++ b/tests/cop_glo30/test_dem_cop.py
@@ -21,6 +21,8 @@ TMP_PATH = CURRENT_DIR / "TMP"
 
 @dataclass
 class TestDem:
+    __test__ = False  # Stop pytest from checking (done because the class starts with the word "Test")
+
     requested_bounds: tuple[float, float, float, float]
     bounds_array_file: str
 

--- a/tests/cop_glo30/test_dem_cop_glo30.py
+++ b/tests/cop_glo30/test_dem_cop_glo30.py
@@ -15,6 +15,8 @@ from dem_handler.dem.cop_glo30 import (
 
 @dataclass
 class TestDem:
+    __test__ = False  # Stop pytest from checking (done because the class starts with the word "Test")
+
     requested_bounds: tuple[float, float, float, float]
     expanded_bounds: tuple[float, float, float, float]
     expanded_shape: tuple[int, int]

--- a/tests/rema/test_dem_rema.py
+++ b/tests/rema/test_dem_rema.py
@@ -23,6 +23,8 @@ TEST_DATA_PATH = CURRENT_DIR / "data"
 # data for tests is downloaded with download_test_data.py script
 @dataclass
 class TestDem:
+    __test__ = False  # Stop pytest from checking (done because the class starts with the word "Test")
+
     requested_bounds: BBox
     dem_file: str
     resolution: int

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -13,6 +13,8 @@ from dem_handler.utils.spatial import (
 
 @dataclass
 class TestValidBounds:
+    __test__ = False  # Stop pytest from checking (done because the class starts with the word "Test")
+
     bounds: BoundingBox
     lat_tol: float
     lon_tol: float
@@ -61,6 +63,8 @@ def test_check_valid_bounding_box(case: TestValidBounds):
 
 @dataclass
 class TestResizeBounds:
+    __test__ = False  # Stop pytest from checking (done because the class starts with the word "Test")
+
     bounds: BoundingBox
     scale_factor: BoundingBox
     resized_bounds: BoundingBox


### PR DESCRIPTION
This PR addresses pytest warnings related to:
- using classes starting with the word "Test" (these need to be ignored by pytest to avoid the warning)
- explicitly stating whether to use gdal exceptions to address "FutureWarning: Neither gdal.UseExceptions() nor gdal.DontUseExceptions() has been explicitly called. In GDAL 4.0, exceptions will be enabled by default." warning